### PR TITLE
Reject all input for DFA without final states

### DIFF
--- a/fa/dfa/DFA.java
+++ b/fa/dfa/DFA.java
@@ -139,6 +139,11 @@ public class DFA implements DFAInterface{
 
     @Override
     public boolean accepts(String s) {
+        // If DFA has no final states, then any input is rejected.
+        if (!hasFinalState) {
+            return false;
+        }
+
         // Split `s` into separate chars for iteration.
         char[] inputChars = s.toCharArray();
 


### PR DESCRIPTION
Does this make sense? If the DFA has no final states, then reject all input strings. There is a class field, `hasFinalState` that checks if the DFA has at least one final state. I check that variable at the beginning 